### PR TITLE
chore(native_storage): 0.2.0

### DIFF
--- a/packages/native/storage/CHANGELOG.md
+++ b/packages/native/storage/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.2.0-wip
+## 0.2.0
 
 - chore: Updates `ffigen` and `jnigen` to latest versions
-- chore: Bumps min SDK to 3.4
+- chore: Support `web: ">=0.5.0 <2.0.0"`
 - fix: Null pointer dereference on Linux `clear`
 
 ## 0.1.7

--- a/packages/native/storage/pubspec.yaml
+++ b/packages/native/storage/pubspec.yaml
@@ -1,10 +1,10 @@
 name: native_storage
 description: A Dart-only package for accessing platform-native storage functionality.
-version: 0.2.0-wip
+version: 0.2.0
 repository: https://github.com/celest-dev/dart-packages/tree/main/packages/native/storage
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.3.0
   flutter: ">=3.19.0"
 
 # Explicitly declare platform support to help `pana`
@@ -24,7 +24,7 @@ dependencies:
   path: ^1.9.0
   stack_trace: ^1.11.1
   stream_channel: ^2.1.2
-  web: ^1.0.0
+  web: '>=0.5.0 <2.0.0'
   win32: ^5.4.0
   win32_registry: ^1.1.2
   windows_applicationmodel: ^0.2.0


### PR DESCRIPTION
- chore: Updates `ffigen` and `jnigen` to latest versions
- chore: Support `web: ">=0.5.0 2.0.0"`
- chore: Bumps min SDK to 3.4
- fix: Null pointer dereference on Linux `clear`