### PR TITLE
fix(storage): Workaround for pkg:web differences pre- and post-v1

### DIFF
--- a/packages/native/storage/CHANGELOG.md
+++ b/packages/native/storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- fix: Workaround for `package:web` differences pre- and post-1.0.0
+
 ## 0.2.0
 
 - chore: Updates `ffigen` and `jnigen` to latest versions

--- a/packages/native/storage/lib/src/isolated/isolated_storage_platform.web.dart
+++ b/packages/native/storage/lib/src/isolated/isolated_storage_platform.web.dart
@@ -63,10 +63,16 @@ self.postMessage('ready');
   Future<void> spawn() async {
     final ready = Completer<void>();
     try {
-      _worker = web.Worker(_workerEntrypoint.toJS);
+      // pkg:web >=1.0.0
+      _worker = web.Worker(_workerEntrypoint.toJS as dynamic);
     } on Object {
-      ready.completeError(NativeStorageException('Failed to spawn worker'));
-      return ready.future;
+      try {
+        // pkg:web <1.0.0
+        _worker = web.Worker(_workerEntrypoint as dynamic);
+      } on Object {
+        ready.completeError(NativeStorageException('Failed to spawn worker'));
+        return ready.future;
+      }
     }
     _worker!.addEventListener(
       'message',

--- a/packages/native/storage/pubspec.yaml
+++ b/packages/native/storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_storage
 description: A Dart-only package for accessing platform-native storage functionality.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/celest-dev/dart-packages/tree/main/packages/native/storage
 
 environment:


### PR DESCRIPTION
The signature of the `Worker` constructor changed in v1 to accept `JSAny` instead of `String`.
The workaround lets both version ranges continue to work for the short term.