### PR TITLE
chore(auth): Simplify web callback session

### DIFF
--- a/packages/native/authentication/CHANGELOG.md
+++ b/packages/native/authentication/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0+1
+
+- chore: Prevent automatically redirecting on Web to allow time for persisting session state.
+
 # 0.1.0
 
 - Initial release

--- a/packages/native/authentication/lib/src/model/callback_session.dart
+++ b/packages/native/authentication/lib/src/model/callback_session.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'package:meta/meta.dart';
 
 /// A session object that represents an ongoing authorization flow.
-sealed class CallbackSession {
+abstract class CallbackSession {
   /// The unique identifier of this session.
   int get id;
 

--- a/packages/native/authentication/lib/src/native_auth.platform_web.dart
+++ b/packages/native/authentication/lib/src/native_auth.platform_web.dart
@@ -7,10 +7,7 @@ import 'package:path/path.dart';
 import 'package:web/web.dart';
 
 final class NativeAuthenticationPlatform implements NativeAuthentication {
-  NativeAuthenticationPlatform({Logger? logger})
-      : _logger = logger ?? Logger('NativeAuthentication');
-
-  final Logger _logger;
+  NativeAuthenticationPlatform({Logger? logger});
 
   /// The base URL, to which all local paths are relative.
   // ignore: unused_element
@@ -20,22 +17,29 @@ final class NativeAuthenticationPlatform implements NativeAuthentication {
     return url.join(window.location.origin, basePath);
   }
 
-  static const _sessionStorageKey = 'dev.celest.native_auth:currentSession';
-
   @override
   CallbackSession startCallback({
     required Uri uri,
     required CallbackType type,
   }) {
-    final sessionId = NativeAuthCallbackSessionImpl.nextId();
-    window.sessionStorage.setItem(_sessionStorageKey, '$sessionId');
-    final session = NativeAuthCallbackSessionImpl(
-      sessionId,
-      Completer<Uri>(),
-      () => window.sessionStorage.removeItem(_sessionStorageKey),
-    );
-    _logger.finer('Redirect flow started');
+    return _NativeAuthCallbackSessionWeb(uri);
+  }
+}
+
+final class _NativeAuthCallbackSessionWeb implements CallbackSession {
+  _NativeAuthCallbackSessionWeb(this.uri);
+
+  final Uri uri;
+
+  @override
+  void cancel() {}
+
+  @override
+  final int id = NativeAuthCallbackSessionImpl.nextId();
+
+  @override
+  Future<Never> get redirectUri async {
     window.open(uri.toString(), '_self');
-    return session;
+    throw const NativeAuthException('Failed to redirect the user');
   }
 }

--- a/packages/native/authentication/pubspec.yaml
+++ b/packages/native/authentication/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_authentication
 description: Native bindings for platform-specific authentication APIs like ASWebAuthenticationSession and Chrome Custom Tabs.
-version: 0.1.0
+version: 0.1.0+1
 repository: https://github.com/celest-dev/dart-packages/tree/main/packages/native/authentication
 
 environment:


### PR DESCRIPTION
Only redirect when the URI has been requested so that there is time to persist state by the calling library.