### PR TITLE
feat(cloud_http): Add utils package

### DIFF
--- a/.github/workflows/cloud_http.yaml
+++ b/.github/workflows/cloud_http.yaml
@@ -1,0 +1,52 @@
+name: cloud_http
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cloud_http.yaml"
+      - "packages/cloud_http/**"
+
+# Prevent duplicate runs due to Graphite
+# https://graphite.dev/docs/troubleshooting#why-are-my-actions-running-twice
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || ''}}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+      matrix:
+        sdk:
+          - stable
+          - "3.3"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
+        with:
+          submodules: recursive
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # 1.6.5
+        with:
+          sdk: ${{ matrix.sdk }}
+      - name: Create override
+        working-directory: packages/cloud_http
+        run: |
+          cat <<EOF > pubspec_overrides.yaml
+          dependency_overrides:
+            http_sfv:
+              path: ../http_sfv
+          EOF
+      - name: Get Packages
+        working-directory: packages/cloud_http
+        run: dart pub get
+      - name: Analyze
+        working-directory: packages/cloud_http
+        run: dart analyze
+      - name: Format
+        working-directory: packages/cloud_http
+        run: dart format --set-exit-if-changed .
+      - name: Test
+        working-directory: packages/cloud_http
+        run: dart test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+pubspec_overrides.yaml

--- a/packages/cloud_http/.gitignore
+++ b/packages/cloud_http/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/cloud_http/CHANGELOG.md
+++ b/packages/cloud_http/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/packages/cloud_http/README.md
+++ b/packages/cloud_http/README.md
@@ -1,0 +1,3 @@
+# cloud_http
+
+Utilities for running Dart server applications in cloud environments.

--- a/packages/cloud_http/analysis_options.yaml
+++ b/packages/cloud_http/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/cloud_http/lib/cloud_http.dart
+++ b/packages/cloud_http/lib/cloud_http.dart
@@ -1,0 +1,5 @@
+library;
+
+export 'src/tracing/trace_context.dart';
+export 'src/tracing/trace_parent.dart';
+export 'src/tracing/trace_state.dart';

--- a/packages/cloud_http/lib/src/tracing/middleware.dart
+++ b/packages/cloud_http/lib/src/tracing/middleware.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+
+import 'package:cloud_http/cloud_http.dart';
+import 'package:convert/convert.dart';
+import 'package:shelf/shelf.dart' as shelf;
+
+/// A trace context [shelf.Middleware] which conforms to the W3C Trace Context
+/// specification.
+///
+/// See: https://w3c.github.io/trace-context/
+shelf.Middleware tracingMiddleware({
+  Random? random,
+}) {
+  random ??= Random.secure();
+  return (shelf.Handler innerHandler) {
+    return (shelf.Request request) {
+      var traceContext = TraceContext.fromHeaders(request.headers);
+      var traceparent = traceContext.traceparent;
+
+      if (traceparent == null) {
+        // A vendor receiving a request without a traceparent header SHOULD
+        // generate traceparent headers for outbound requests, effectively
+        // starting a new trace.
+        traceparent = Traceparent.create(
+          traceId: hex.encode(
+            List<int>.generate(16, (_) => random!.nextInt(256)),
+          ),
+          parentId: hex.encode(
+            List<int>.generate(8, (_) => random!.nextInt(256)),
+          ),
+          sampled: true,
+          random: true,
+        );
+      } else {
+        // https://www.w3.org/TR/trace-context-2/#a-traceparent-is-received
+        //
+        // The vendor MUST modify the traceparent header:
+        // - Update parent-id: The value of property parent-id MUST be set to a
+        //   value representing the ID of the current operation.
+        // - Update sampled: The value of sampled reflects the caller's
+        //   recording behavior. The value of the sampled flag of trace-flags
+        //   MAY be set to 1 if the trace data is likely to be recorded or to 0
+        //   otherwise. Setting the flag is no guarantee that the trace will be
+        //   recorded but increases the likeliness of end-to-end recorded traces.
+        traceparent = traceparent.copyWith(
+          parentId: hex.encode(
+            List<int>.generate(8, (_) => random!.nextInt(256)),
+          ),
+          sampled: true,
+        );
+      }
+
+      traceContext = TraceContext(
+        traceparent: traceparent,
+        tracestate: traceContext.tracestate,
+      );
+
+      return innerHandler(
+        request.change(headers: {
+          ...request.headers,
+          ...traceContext.toHeaders(),
+        }),
+      );
+    };
+  };
+}

--- a/packages/cloud_http/lib/src/tracing/trace_context.dart
+++ b/packages/cloud_http/lib/src/tracing/trace_context.dart
@@ -1,0 +1,76 @@
+import 'package:cloud_http/src/tracing/trace_parent.dart';
+import 'package:cloud_http/src/tracing/trace_state.dart';
+
+/// The trace context for a request, as defined in the W3C Trace Context
+/// [specification](https://www.w3.org/TR/trace-context-2).
+final class TraceContext {
+  const TraceContext({
+    required Traceparent this.traceparent,
+    this.tracestate,
+  });
+
+  const TraceContext._({
+    this.traceparent,
+    this.tracestate,
+  });
+
+  /// Parses the `traceparent` and `tracestate` headers from a request's
+  /// [headers].
+  ///
+  /// If the `traceparent` header is missing or invalid, the returned context
+  /// will have a
+  ///
+  /// If the `tracestate` header is missing or invalid, the returned context
+  /// will have a `null` [tracestate].
+  ///
+  /// Assumes that [headers] is a case-insensitive [Map].
+  factory TraceContext.fromHeaders(Map<String, Object>? headers) {
+    final traceparentHeader = switch (headers?['traceparent']) {
+      null => null,
+      final String traceparent => traceparent,
+      final List<String> traceparent => traceparent.singleOrNull,
+      final invalid => throw FormatException(
+          'Invalid traceparent header: $invalid. '
+          'Expected String or List<String>, got ${invalid.runtimeType}.',
+        ),
+    };
+    final traceparent = traceparentHeader != null
+        ? Traceparent.tryParse(traceparentHeader)
+        : null;
+    // If the vendor failed to parse traceparent, it MUST NOT attempt to parse
+    // tracestate. Note that the opposite is not true: failure to parse
+    // tracestate MUST NOT affect the parsing of traceparent.
+    Tracestate? tracestate;
+    if (traceparent != null) {
+      final tracestateHeader = switch (headers?['tracestate']) {
+        null => null,
+        final String tracestate => tracestate,
+        // Multiple tracestate header fields MUST be handled as specified by
+        // RFC9110 Section 5.3 Field Order.
+        final List<String> tracestate => tracestate.join(', '),
+        final invalid => throw FormatException(
+            'Invalid tracestate header: $invalid. '
+            'Expected String or List<String>, got ${invalid.runtimeType}.',
+          ),
+      };
+      tracestate = tracestateHeader != null
+          ? Tracestate.tryParse(tracestateHeader)
+          : null;
+    }
+    return TraceContext._(
+      traceparent: traceparent,
+      tracestate: tracestate,
+    );
+  }
+
+  final Traceparent? traceparent;
+  final Tracestate? tracestate;
+
+  Map<String, String> toHeaders() => {
+        // In order to increase interoperability across multiple protocols and
+        // encourage successful integration, tracing systems SHOULD encode the
+        // header name as ASCII lowercase.
+        if (traceparent != null) 'traceparent': traceparent.toString(),
+        if (tracestate != null) 'tracestate': tracestate.toString(),
+      };
+}

--- a/packages/cloud_http/lib/src/tracing/trace_parent.dart
+++ b/packages/cloud_http/lib/src/tracing/trace_parent.dart
@@ -1,0 +1,320 @@
+// ignore: implementation_imports
+import 'package:http_sfv/src/character.dart';
+
+/// {@template cloud_http.traceparent}
+/// The parsed value of the `traceparent` header as defined in the W3C Trace Context specification.
+///
+/// See: https://www.w3.org/TR/trace-context/#traceparent-header
+/// {@endtemplate}
+final class Traceparent {
+  /// {@macro cloud_http.traceparent}
+  const Traceparent({
+    required this.traceId,
+    required this.parentId,
+    required this.traceFlags,
+    required this.version,
+    this.unknownFields,
+  });
+
+  /// Creates a [Traceparent] for the given request-scoped [traceId] and
+  /// [parentId].
+  factory Traceparent.create({
+    required String traceId,
+    required String parentId,
+    bool sampled = true,
+    bool random = false,
+  }) {
+    return Traceparent(
+      traceId: traceId,
+      parentId: parentId,
+      traceFlags:
+          (sampled ? _traceFlagSampled : 0) | (random ? _traceFlagRandom : 0),
+      version: defaultVersion,
+    );
+  }
+
+  /// Parses the [traceparent] header.
+  ///
+  /// Throws a [FormatException] for invalid header formats. Use [tryParse] to
+  /// discard parsing errors.
+  ///
+  /// {@template cloud_http.traceparent.format}
+  /// ## Format
+  ///
+  ///     version-traceId-parentId-traceFlags
+  ///
+  /// where:
+  /// - `version` is a single byte (8-bit unsigned integer) that represents the
+  ///    version of the traceparent.
+  /// - `traceId` is a 16-byte array that represents the ID of the whole trace
+  ///    forest.
+  /// - `parentId` is an 8-byte array that represents the ID of this request as
+  ///    known by the caller.
+  /// - `traceFlags` is an 8-bit field that controls tracing flags such as
+  ///    sampling, trace level, etc.
+  /// {@endtemplate}
+  factory Traceparent.parse(String traceparent) {
+    // If the size of the header is shorter than 55 characters, the vendor
+    // should not parse the header and should restart the trace.
+    if (traceparent.length < 55) {
+      throw FormatException(
+        'Invalid traceparent header. Unexpected length: '
+        '${traceparent.length} < 55',
+        traceparent,
+      );
+    }
+
+    final codeUnits = traceparent.codeUnits as List<Character>;
+
+    final versionPart = traceparent.substring(0, 2);
+    final version = int.tryParse(versionPart, radix: 16);
+    if (version == null) {
+      throw FormatException(
+        'Invalid traceparent version: $version',
+        traceparent,
+        0,
+      );
+    }
+    const invalidVersion = 0xff;
+    if (version == invalidVersion) {
+      throw FormatException(
+        'Invalid traceparent version: $version',
+        traceparent,
+        0,
+      );
+    }
+    if (version != defaultVersion) {
+      // OK. If a higher version is detected, the implementation SHOULD try to
+      // parse it.
+    }
+
+    var offset = 2;
+    if (codeUnits[offset++] != Character.dash) {
+      throw FormatException(
+        'Invalid traceparent header. Expected dash at offset 2',
+        traceparent,
+        2,
+      );
+    }
+
+    const traceIdLength = 32;
+    final traceId = traceparent.substring(offset, offset + traceIdLength);
+    final traceIdCodeUnits = traceId.codeUnits as List<Character>;
+    if (traceIdCodeUnits.every((char) => char == Character.zero)) {
+      throw FormatException(
+        'Invalid traceparent traceId: $traceId',
+        traceparent,
+        offset,
+      );
+    }
+    for (final traceIdChar in traceIdCodeUnits) {
+      if (!traceIdChar.isValidHex) {
+        throw FormatException(
+          'Invalid traceparent traceId: $traceId',
+          traceparent,
+          offset,
+        );
+      }
+    }
+
+    offset += traceIdLength;
+    if (codeUnits[offset++] != Character.dash) {
+      throw FormatException(
+        'Invalid traceparent header. Expected dash at offset 34',
+        traceparent,
+        34,
+      );
+    }
+
+    const parentIdLength = 16;
+    final parentId = traceparent.substring(offset, offset + parentIdLength);
+    final parentIdCodeUnits = parentId.codeUnits as List<Character>;
+    if (parentIdCodeUnits.every((char) => char == Character.zero)) {
+      throw FormatException(
+        'Invalid traceparent parentId: $parentId',
+        traceparent,
+        offset,
+      );
+    }
+    for (final parentIdChar in parentIdCodeUnits) {
+      if (!parentIdChar.isValidHex) {
+        throw FormatException(
+          'Invalid traceparent parentId: $parentId',
+          traceparent,
+          offset,
+        );
+      }
+    }
+
+    offset += parentIdLength;
+    if (codeUnits[offset++] != Character.dash) {
+      throw FormatException(
+        'Invalid traceparent header. Expected dash at offset 50',
+        traceparent,
+        50,
+      );
+    }
+
+    final traceFlagsPart = traceparent.substring(offset, offset + 2);
+    final traceFlags = int.tryParse(traceFlagsPart, radix: 16);
+    if (traceFlags == null) {
+      throw FormatException(
+        'Invalid traceparent traceFlags: $traceFlags',
+        traceparent,
+        offset,
+      );
+    }
+
+    offset += 2;
+
+    String? unknownFields;
+    // Vendors MUST check that the 2 characters are either the end of the string
+    // or a dash.
+    if (offset == traceparent.length) {
+      // OK
+    } else if (version == defaultVersion) {
+      // Invalid for current spec
+      throw FormatException(
+        'Invalid traceparent header. Unexpected length: '
+        '${traceparent.length} > 55',
+        traceparent,
+        offset,
+      );
+    } else {
+      if (codeUnits[offset++] != Character.dash) {
+        throw FormatException(
+          'Invalid traceparent header. Expected dash at offset 52',
+          traceparent,
+          52,
+        );
+      }
+      unknownFields = traceparent.substring(offset);
+    }
+
+    return Traceparent(
+      version: version,
+      traceId: traceId,
+      parentId: parentId,
+      traceFlags: traceFlags,
+      unknownFields: unknownFields,
+    );
+  }
+
+  /// Tries to parse the [traceparent] header.
+  ///
+  /// {@macro cloud_http.traceparent.format}
+  static Traceparent? tryParse(String traceparent) {
+    try {
+      return Traceparent.parse(traceparent);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  static const int defaultVersion = 0x00; // 0 is the only defined version
+
+  /// Version (version) is 1 byte representing an 8-bit unsigned integer.
+  ///
+  /// Version `ff` is invalid. The current specification assumes the version
+  /// is set to `00`.
+  final int version;
+
+  /// This is the ID of the whole trace forest and is used to uniquely identify
+  /// a distributed trace through a system.
+  ///
+  /// It is represented as a 16-byte array, for example,
+  /// `4bf92f3577b34da6a3ce929d0e0e4736`.
+  final String traceId;
+
+  /// This is the ID of this request as known by the caller.
+  ///
+  /// In some tracing systems, this is known as the `span-id`, where a `span`
+  /// is the execution of a client request.
+  ///
+  /// It is represented as an 8-byte array, for example, `00f067aa0ba902b7`.
+  final String parentId;
+
+  /// An 8-bit field that controls tracing flags such as sampling, trace level,
+  /// etc.
+  final int traceFlags;
+
+  static const int _traceFlagSampled = 1 << 0;
+  static const int _traceFlagRandom = 1 << 1;
+
+  /// When set, the least significant bit (right-most), denotes that the caller
+  /// may have recorded trace data.
+  ///
+  /// When unset, the caller did not record trace data out-of-band.
+  int get traceFlagSampled => traceFlags & _traceFlagSampled;
+
+  /// Level 2
+  ///
+  /// When set, the second least significant bit (right-most), denotes that the
+  /// right-most 7 bytes of the [traceId] are randomly (or pseudo-randomly)
+  /// generated.
+  ///
+  /// See: https://www.w3.org/TR/trace-context-2/#random-trace-id-flag
+  int get traceFlagRandom => traceFlags & _traceFlagRandom;
+
+  /// Unparsed fields which trail the header.
+  final String? unknownFields;
+
+  Traceparent copyWith({
+    String? traceId,
+    String? parentId,
+    bool? sampled,
+    bool? random,
+  }) {
+    return Traceparent(
+      version: version,
+      traceId: traceId ?? this.traceId,
+      parentId: parentId ?? this.parentId,
+      traceFlags: traceFlags |
+          (sampled == true ? _traceFlagSampled : 0) |
+          (random == true ? _traceFlagRandom : 0),
+      unknownFields: unknownFields,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Traceparent &&
+        other.version == version &&
+        other.traceId == traceId &&
+        other.parentId == parentId &&
+        other.traceFlags == traceFlags &&
+        other.unknownFields == unknownFields;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        version,
+        traceId,
+        parentId,
+        traceFlags,
+        unknownFields,
+      );
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.write('00');
+    buffer.writeCharCode(Character.dash);
+    buffer.write(traceId);
+    buffer.writeCharCode(Character.dash);
+    buffer.write(parentId);
+    buffer.writeCharCode(Character.dash);
+    buffer.write(traceFlags.toRadixString(16).padLeft(2, '0'));
+    if (unknownFields != null) {
+      /// Vendors MUST NOT parse or assume anything about unknown fields for
+      /// this version. Vendors MUST use these fields to construct the new
+      /// traceparent field according to the highest version of the
+      /// specification known to the implementation (in this specification it
+      /// is `00`).
+      buffer.writeCharCode(Character.dash);
+      buffer.write(unknownFields);
+    }
+    return buffer.toString();
+  }
+}

--- a/packages/cloud_http/lib/src/tracing/trace_state.dart
+++ b/packages/cloud_http/lib/src/tracing/trace_state.dart
@@ -1,0 +1,303 @@
+import 'dart:collection';
+
+// ignore: implementation_imports
+import 'package:http_sfv/src/character.dart';
+
+/// {@template cloud_http.tracestate}
+/// The parsed value of the `tracestate` header as defined in the W3C Trace
+/// Context specification.
+///
+/// See: https://www.w3.org/TR/trace-context-2/#tracestate-header
+/// {@endtemplate}
+final class Tracestate extends UnmodifiableMapBase<TracestateKey, String> {
+  /// {@macro cloud_http.tracestate}
+  Tracestate(this._map);
+
+  /// Creates a [Tracestate] from a [Map].
+  ///
+  /// Throws a [FormatException] if the map contains invalid keys or values.
+  factory Tracestate.from(Map<String, String> map) {
+    return Tracestate(
+      map.map((k, v) => MapEntry(TracestateKey.parse(k), v)),
+    );
+  }
+
+  /// Parses the [tracestate] header.
+  ///
+  /// Throws a [FormatException] for invalid header formats. Use [tryParse] to
+  /// discard parsing errors.
+  factory Tracestate.parse(String tracestate) {
+    final parser = _TracestateParser(tracestate);
+    final values = parser.parse();
+    final numValues = values.length;
+    final maxValues = 32;
+    if (numValues > maxValues) {
+      throw FormatException(
+        'Too many entries ($numValues > $maxValues)',
+        tracestate,
+      );
+    }
+    return Tracestate(values);
+  }
+
+  /// Tries to parse the [tracestate] header.
+  static Tracestate? tryParse(String tracestate) {
+    try {
+      return Tracestate.parse(tracestate);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  final Map<TracestateKey, String> _map;
+
+  @override
+  String? operator [](Object? key) => _map[key as TracestateKey];
+
+  @override
+  Iterable<TracestateKey> get keys => _map.keys;
+
+  @override
+  String toString() {
+    return _map.entries.map((entry) => '${entry.key}=${entry.value}').join(',');
+  }
+}
+
+final class _TracestateParser {
+  _TracestateParser(this.header)
+      : _codeUnits = header.codeUnits as List<Character>;
+
+  final String header;
+  final List<Character> _codeUnits;
+  int _offset = 0;
+
+  bool get isEof => _offset == _codeUnits.length;
+  Never _unexpectedEof() => throw FormatException('Unexpected end of input');
+
+  Character _peek() {
+    if (isEof) _unexpectedEof();
+    return _codeUnits[_offset];
+  }
+
+  void _skipOptionalWhitespace() {
+    while (!isEof) {
+      final char = _peek();
+      if (char != Character.space && char != Character.tab) {
+        return;
+      }
+      _offset++;
+    }
+  }
+
+  TracestateKey _parseKey() {
+    final start = _offset;
+    while (!isEof) {
+      final char = _peek();
+      if (!char.isValidTracestateKeyChar && char != Character.at) {
+        break;
+      }
+      _offset++;
+    }
+    final key = header.substring(start, _offset);
+    return TracestateKey.parse(key);
+  }
+
+  String _parseValue() {
+    final start = _offset;
+    int? end;
+    var leadingWhitespace = true;
+    while (!isEof) {
+      final char = _peek();
+      if (char == Character.comma) {
+        break;
+      }
+      // All leading spaces MUST be preserved as part of the value.
+      //
+      // All trailing spaces are considered to be optional whitespace characters
+      // not part of the value. Optional trailing whitespace MAY be excluded
+      // when propagating the header.
+      if (char == Character.space) {
+        _offset++;
+        if (!leadingWhitespace) {
+          end ??= _offset;
+        }
+        continue;
+      }
+      if (!char.isValidTracestateValueChar) {
+        throw FormatException('Invalid value character', header, _offset);
+      }
+      leadingWhitespace = false;
+      end = ++_offset;
+    }
+    end ??= _offset;
+    if (start == end || leadingWhitespace) {
+      throw FormatException('Empty value', header, end);
+    }
+    final length = end - start;
+    const maxLength = 256;
+    if (length > maxLength) {
+      throw FormatException(
+        'Value too long ($length > $maxLength)',
+        header,
+        end,
+      );
+    }
+    final value = header.substring(start, end);
+    return value;
+  }
+
+  Map<TracestateKey, String> parse() {
+    final values = <TracestateKey, String>{};
+
+    while (!isEof) {
+      _skipOptionalWhitespace();
+      final key = _parseKey();
+      _skipOptionalWhitespace();
+      if (_peek() case != Character.equals && != Character.at) {
+        throw FormatException('Expected "="');
+      }
+      _offset++;
+      final value = _parseValue();
+      values[key] = value;
+      if (!isEof && _peek() == Character.comma) {
+        _offset++;
+      }
+    }
+
+    return values;
+  }
+}
+
+sealed class TracestateKey {
+  const TracestateKey._();
+
+  factory TracestateKey.parse(String key) {
+    final at = key.indexOf('@');
+    if (at == -1) {
+      return TracestateSimpleKey(key);
+    }
+    return TracestateMultiTenantKey(
+      tenantId: key.substring(0, at),
+      systemId: key.substring(at + 1),
+    );
+  }
+
+  String get key;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TracestateKey && key == other.key;
+  }
+
+  @override
+  int get hashCode => key.hashCode;
+
+  @override
+  String toString() => key;
+}
+
+extension TracestateCharacter on Character {
+  /// Section [3.3.2.2.1](https://www.w3.org/TR/trace-context-2/#key)
+  ///
+  ///     key = ( lcalpha / DIGIT ) 0*255 ( keychar )
+  ///     keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
+  ///     lcalpha    = %x61-7A ; a-z
+  bool get isValidTracestateKeyChar =>
+      isLowerAlpha ||
+      isDigit ||
+      this == Character.underscore ||
+      this == Character.dash ||
+      this == Character.star ||
+      this == Character.slash;
+
+  /// Section [3.3.2.2.2](https://www.w3.org/TR/trace-context-2/#value)
+  ///
+  ///     value    = 0*255(chr) nblk-chr
+  ///     nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
+  ///     chr      = %x20 / nblk-chr
+  bool get isValidTracestateValueChar =>
+      (this >= 0x21 && this <= 0x2B) ||
+      (this >= 0x2D && this <= 0x3C) ||
+      (this >= 0x3E && this <= 0x7E);
+}
+
+final class TracestateSimpleKey extends TracestateKey {
+  factory TracestateSimpleKey(String key) {
+    if (key.isEmpty || key.length > maxLength) {
+      _badKey(key);
+    }
+    final codeUnits = key.codeUnits as List<Character>;
+    if (!codeUnits[0].isLowerAlpha ||
+        codeUnits.any((char) => !char.isValidTracestateKeyChar)) {
+      _badKey(key);
+    }
+    return TracestateSimpleKey.raw(key);
+  }
+
+  const TracestateSimpleKey.raw(this.key) : super._();
+
+  static const int maxLength = 256;
+  static Never _badKey(String key) => throw FormatException(
+        'key "$key" must conform to the ABNF grammar: '
+        'simple-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )',
+      );
+
+  @override
+  final String key;
+}
+
+final class TracestateMultiTenantKey extends TracestateKey {
+  factory TracestateMultiTenantKey({
+    required String tenantId,
+    required String systemId,
+  }) {
+    if (tenantId.isEmpty || tenantId.length > _tenantIdMaxLength) {
+      _badTenantId(tenantId);
+    }
+    final tenantIdCodeUnits = tenantId.codeUnits as List<Character>;
+    if (!tenantIdCodeUnits[0].isLowerAlpha && !tenantIdCodeUnits[0].isDigit) {
+      _badTenantId(tenantId);
+    }
+    if (tenantIdCodeUnits.any((char) => !char.isValidTracestateKeyChar)) {
+      _badTenantId(tenantId);
+    }
+
+    if (systemId.isEmpty || systemId.length > _systemIdMaxLength) {
+      _badSystemId(systemId);
+    }
+    final systemIdCodeUnits = systemId.codeUnits as List<Character>;
+    if (!systemIdCodeUnits[0].isLowerAlpha) {
+      _badSystemId(systemId);
+    }
+    if (systemIdCodeUnits.any((char) => !char.isValidTracestateKeyChar)) {
+      _badSystemId(systemId);
+    }
+    return TracestateMultiTenantKey.raw(
+      tenantId: tenantId,
+      systemId: systemId,
+    );
+  }
+
+  const TracestateMultiTenantKey.raw({
+    required this.tenantId,
+    required this.systemId,
+  }) : super._();
+
+  static const int _tenantIdMaxLength = 241;
+  static Never _badTenantId(String tenantId) => throw FormatException(
+        'tenantId "$tenantId" must conform to the ABNF grammar: '
+        'tenant-id = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )',
+      );
+
+  static const int _systemIdMaxLength = 14;
+  static Never _badSystemId(String systemId) => throw FormatException(
+        'systemId "$systemId" must conform to the ABNF grammar: '
+        'system-id = lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )',
+      );
+
+  @override
+  String get key => '$tenantId@$systemId';
+
+  final String tenantId;
+  final String systemId;
+}

--- a/packages/cloud_http/pubspec.yaml
+++ b/packages/cloud_http/pubspec.yaml
@@ -1,0 +1,17 @@
+name: cloud_http
+description: Utilities for running Dart server applications in cloud environments.
+version: 0.1.0
+
+environment:
+  sdk: ^3.3.0
+
+dependencies:
+  async: ^2.10.0
+  convert: ^3.1.1
+  http_sfv: ^0.1.0
+  shelf: ^1.4.0
+  string_scanner: ^1.2.0
+
+dev_dependencies:
+  lints: ^4.0.0
+  test: ^1.24.0

--- a/packages/cloud_http/test/tracing/trace_context_test.dart
+++ b/packages/cloud_http/test/tracing/trace_context_test.dart
@@ -1,0 +1,130 @@
+import 'package:cloud_http/src/tracing/trace_context.dart';
+import 'package:cloud_http/src/tracing/trace_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TraceContext', () {
+    group('fromHeaders', () {
+      test('missing traceparent, missing tracestate', () {
+        final context = TraceContext.fromHeaders({});
+        expect(context.traceparent, isNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('missing traceparent, invalid tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'tracestate': 'invalid',
+        });
+        expect(context.traceparent, isNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('invalid traceparent, missing tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent': 'invalid',
+        });
+        expect(context.traceparent, isNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('invalid traceparent, invalid tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent': 'invalid',
+          'tracestate': 'invalid',
+        });
+        expect(context.traceparent, isNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('valid traceparent, missing tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+        });
+        expect(context.traceparent, isNotNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('valid traceparent, invalid tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': 'invalid',
+        });
+        expect(context.traceparent, isNotNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('valid traceparent, valid tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': 'key=value',
+        });
+        expect(context.traceparent, isNotNull);
+        expect(context.tracestate, isNotNull);
+      });
+
+      test('valid traceparent, valid tracestate (multiple values)', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': ['key=value', 'key2=value2'],
+        });
+        expect(context.traceparent, isNotNull);
+        expect(
+          context.tracestate,
+          Tracestate.from({
+            'key': 'value',
+            'key2': 'value2',
+          }),
+        );
+      });
+
+      test('valid traceparent, valid tracestate (list)', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': ['key=value'],
+        });
+        expect(context.traceparent, isNotNull);
+        expect(
+          context.tracestate,
+          Tracestate.from({
+            'key': 'value',
+          }),
+        );
+      });
+
+      test('valid traceparent, valid tracestate (invalid key)', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': 'key',
+        });
+        expect(context.traceparent, isNotNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('valid traceparent, valid tracestate (invalid value)', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': 'key= ',
+        });
+        expect(context.traceparent, isNotNull);
+        expect(context.tracestate, isNull);
+      });
+
+      test('invalid traceparent, valid tracestate', () {
+        final context = TraceContext.fromHeaders({
+          'traceparent':
+              'ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+          'tracestate': 'key=value',
+        });
+        expect(context.traceparent, isNull);
+        expect(context.tracestate, isNull);
+      });
+    });
+  });
+}

--- a/packages/cloud_http/test/tracing/trace_parent_test.dart
+++ b/packages/cloud_http/test/tracing/trace_parent_test.dart
@@ -1,0 +1,104 @@
+import 'package:cloud_http/src/tracing/trace_parent.dart';
+import 'package:test/test.dart';
+
+typedef TraceparentTest = (
+  String name,
+  bool valid,
+  String header,
+  Traceparent? expected,
+);
+
+final traceparentTests = <TraceparentTest>[
+  (
+    'sampled',
+    true,
+    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+    Traceparent(
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      parentId: 'b7ad6b7169203331',
+      traceFlags: 0x01,
+      version: 0x00,
+    ),
+  ),
+  (
+    'unsampled',
+    true,
+    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00',
+    Traceparent(
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      parentId: 'b7ad6b7169203331',
+      traceFlags: 0x00,
+      version: 0x00,
+    ),
+  ),
+  (
+    'invalid version (0xff)',
+    false,
+    'ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00',
+    null,
+  ),
+  (
+    'invalid trace ID',
+    false,
+    '00-${'0' * 32}-b7ad6b7169203331-00',
+    null,
+  ),
+  (
+    'invalid parent ID',
+    false,
+    '00-0af7651916cd43dd8448eb211c80319c-${'0' * 16}-00',
+    null,
+  ),
+  (
+    'unknown version',
+    true,
+    '01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00',
+    Traceparent(
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      parentId: 'b7ad6b7169203331',
+      traceFlags: 0x00,
+      version: 0x01,
+    ),
+  ),
+  (
+    'unknown fields',
+    false,
+    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00-unknown',
+    null,
+  ),
+  (
+    'unknown fields (unknown version)',
+    true,
+    '01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00-unknown',
+    Traceparent(
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      parentId: 'b7ad6b7169203331',
+      traceFlags: 0x00,
+      version: 0x01,
+      unknownFields: 'unknown',
+    ),
+  )
+];
+
+void main() {
+  group('Traceparent', () {
+    group('parse', () {
+      for (final testCase in traceparentTests) {
+        final (name, valid, header, expected) = testCase;
+        test(name, () {
+          if (valid) {
+            final traceparent = Traceparent.tryParse(header);
+            expect(traceparent, expected);
+            expect(
+              traceparent.toString(),
+              '00-${header.substring(3)}',
+              reason: 'toString() always uses the default version',
+            );
+          } else {
+            expect(Traceparent.tryParse(header), isNull);
+          }
+        });
+      }
+    });
+  });
+}

--- a/packages/cloud_http/test/tracing/trace_state_test.dart
+++ b/packages/cloud_http/test/tracing/trace_state_test.dart
@@ -1,0 +1,179 @@
+import 'package:cloud_http/src/tracing/trace_state.dart';
+// ignore: implementation_imports
+import 'package:http_sfv/src/character.dart';
+import 'package:test/test.dart';
+
+typedef TracestateTest = (
+  String name,
+  bool valid,
+  String header,
+  Tracestate? expected,
+  String? expectedString,
+);
+
+final tracestateTests = <TracestateTest>[
+  (
+    'single key',
+    true,
+    'key=value',
+    Tracestate.from({'key': 'value'}),
+    null,
+  ),
+  (
+    'multi key',
+    true,
+    'key1=value1,key2=value2',
+    Tracestate.from({'key1': 'value1', 'key2': 'value2'}),
+    null,
+  ),
+  (
+    'multi tenant key',
+    true,
+    'tenant1@system1=value1,tenant2@system2=value2',
+    Tracestate.from({
+      'tenant1@system1': 'value1',
+      'tenant2@system2': 'value2',
+    }),
+    null,
+  ),
+  (
+    // 3.3.2.2.2: All leading spaces MUST be preserved as part of the value.
+    'leading value whitespace is preserved',
+    true,
+    'key=  value',
+    Tracestate.from({'key': '  value'}),
+    null,
+  ),
+  (
+    'trailing value whitespace is ignored',
+    true,
+    'key=value ',
+    Tracestate.from({'key': 'value'}),
+    'key=value',
+  ),
+  (
+    'optional whitespace is ignored',
+    true,
+    'key=value  ,  key2=value2,  key3=value3  ',
+    Tracestate.from({
+      'key': 'value',
+      'key2': 'value2',
+      'key3': 'value3',
+    }),
+    'key=value,key2=value2,key3=value3',
+  ),
+  (
+    'invalid key/value pair',
+    false,
+    'key',
+    null,
+    null,
+  ),
+  (
+    'empty value',
+    false,
+    'key=',
+    null,
+    null,
+  ),
+  (
+    'empty value: only whitespace',
+    false,
+    'key=  ',
+    null,
+    null,
+  ),
+  (
+    'valid whitespace within value',
+    true,
+    'key=va  lue',
+    Tracestate.from({'key': 'va  lue'}),
+    null,
+  ),
+  for (var i = 0; i < Character.maxAscii; i++)
+    if (Character(i).isValidTracestateValueChar)
+      (
+        'valid value char: 0x${i.toRadixString(16).padLeft(2, '0')}',
+        true,
+        'key=${String.fromCharCode(i)}',
+        Tracestate.from({'key': String.fromCharCode(i)}),
+        null,
+      )
+    else
+      (
+        'invalid value char: 0x${i.toRadixString(16).padLeft(2, '0')}',
+        false,
+        'key=${String.fromCharCode(i)}',
+        null,
+        null,
+      ),
+  (
+    'value at length',
+    false,
+    'key=${'a' * 256}',
+    null,
+    null,
+  ),
+  (
+    'value too long',
+    false,
+    'key=${'a' * 257}',
+    null,
+    null,
+  ),
+  (
+    'too many values',
+    false,
+    [
+      for (var i = 0; i < 33; i++) 'key$i=value$i',
+    ].join(','),
+    null,
+    null,
+  ),
+  (
+    'takes second value for dup keys',
+    true,
+    'key=value1,key=value2',
+    Tracestate.from({'key': 'value2'}),
+    'key=value2',
+  ),
+  (
+    'invalid multi tenant key',
+    false,
+    'tenant1@system1',
+    null,
+    null,
+  ),
+  (
+    'invalid multi tenant value',
+    false,
+    'tenant1@system1=',
+    null,
+    null,
+  ),
+];
+
+void main() {
+  group('Tracestate', () {
+    group('parse', () {
+      for (final testCase in tracestateTests) {
+        final (name, valid, header, expected, expectedToString) = testCase;
+
+        test(name, () {
+          try {
+            final tracestate = Tracestate.parse(header);
+            if (!valid) {
+              fail('Expected exception');
+            }
+            expect(tracestate, expected);
+            expect(tracestate.toString(), expectedToString ?? header);
+          } on Object catch (e, st) {
+            if (valid) {
+              fail('Unexpected exception: $e\n$st');
+            }
+          }
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
Adds a package with helpers for running Dart server apps in a cloud environments. Includes tracing and logging helpers.