### PR TITLE
fix(native_authentication): Add default redirect scheme on Android

### DIFF
--- a/packages/native/authentication/CHANGELOG.md
+++ b/packages/native/authentication/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1+1
+
+- fix: Add default redirect scheme on Android
+
 # 0.1.1
 
 - chore: Update dependencies

--- a/packages/native/authentication/android/src/main/AndroidManifest.xml
+++ b/packages/native/authentication/android/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="${nativeAuthRedirectScheme}" />
+                <data android:scheme="celest" />
             </intent-filter>
         </activity>
     </application>

--- a/packages/native/authentication/example/android/app/build.gradle
+++ b/packages/native/authentication/example/android/app/build.gradle
@@ -25,8 +25,6 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-
-        manifestPlaceholders["nativeAuthRedirectScheme"] = "celest"
     }
 
     ndkVersion = "26.1.10909125"

--- a/packages/native/authentication/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/native/authentication/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application
         android:label="native_auth_flutter_example"
         android:name="${applicationName}"
@@ -23,6 +24,21 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+
+        <!-- Overrides the default redirect scheme as described here: 
+             https://github.com/openid/AppAuth-Android/blob/4df1ebac07436d7e8d68cbb98207cc40fe55a39d/README.md?plain=1#L282 -->
+        <activity
+            android:name="dev.celest.native_authentication.CallbackReceiverActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay"
+            tools:node="replace">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="test" />
             </intent-filter>
         </activity>
 

--- a/packages/native/authentication/pubspec.yaml
+++ b/packages/native/authentication/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_authentication
 description: Native bindings for platform-specific authentication APIs like ASWebAuthenticationSession and Chrome Custom Tabs.
-version: 0.1.1
+version: 0.1.1+1
 repository: https://github.com/celest-dev/dart-packages/tree/main/packages/native/authentication
 
 environment:


### PR DESCRIPTION
For packages which depend on `native_authentication` but do not require native support, add a default placeholder so that
Android apps correctly build.