### PR TITLE
ci: Use smaller macOS runners

### DIFF
--- a/.github/workflows/native_authentication.yaml
+++ b/.github/workflows/native_authentication.yaml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     timeout-minutes: 25
     steps:
       - name: Git Checkout

--- a/.github/workflows/native_storage.yaml
+++ b/.github/workflows/native_storage.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: packages/native/storage
         run: dart format --set-exit-if-changed .
   test_darwin:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest-xlarge # Tests timeout on smaller `macos-latest` runner
     timeout-minutes: 20
     steps:
       - name: Git Checkout


### PR DESCRIPTION
To avoid the costs of XL runners which are not currently worth it.