### PR TITLE
fix(native_storage): Return deleted values

### DIFF
--- a/packages/native/storage/CHANGELOG.md
+++ b/packages/native/storage/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix!: Don't set a default namespace on Web
 - fix!: Align namespace/scope prefix with `shared_preferences` on Web
+- fix: Return deleted value
 
 ## 0.2.3
 

--- a/packages/native/storage/android/src/main/kotlin/dev/celest/native_storage/NativeStorage.kt
+++ b/packages/native/storage/android/src/main/kotlin/dev/celest/native_storage/NativeStorage.kt
@@ -45,7 +45,8 @@ sealed class NativeStorage(
     }
 
     fun delete(key: String): String? {
-        val current = read("$prefix$key")
+        println("Deleting: $prefix$key")
+        val current = sharedPreferences.getString("$prefix$key", null)
         with(editor) {
             remove("$prefix$key")
             apply()

--- a/packages/native/storage/example/integration_test/storage_shared.dart
+++ b/packages/native/storage/example/integration_test/storage_shared.dart
@@ -119,7 +119,8 @@ void sharedTests(NativeStorageType type, NativeStorageFactory factory_) {
                     reason: 'Value was written');
                 expect(storage.allKeys, equals([key]));
 
-                storage.delete(key);
+                final deletedValue = storage.delete(key);
+                expect(deletedValue, 'delete', reason: 'Value was deleted');
                 expect(storage.read(key), isNull, reason: 'Value was deleted');
                 expect(storage.allKeys, isEmpty);
               });

--- a/packages/native/storage/lib/src/local/local_storage_darwin.dart
+++ b/packages/native/storage/lib/src/local/local_storage_darwin.dart
@@ -43,7 +43,7 @@ final class LocalStoragePlatformDarwin extends NativeLocalStoragePlatform {
 
   @override
   String? delete(String key) {
-    final existing = read('$_prefix$key');
+    final existing = read(key);
     _userDefaults.removeObjectForKey_(darwin.nsString('$_prefix$key'));
     return existing;
   }

--- a/packages/native/storage/lib/src/local/local_storage_platform.web.dart
+++ b/packages/native/storage/lib/src/local/local_storage_platform.web.dart
@@ -45,7 +45,7 @@ final class NativeLocalStoragePlatform extends NativeStorageBase
     if (value != null) {
       _storage.removeItem('$_prefix$key');
     }
-    return null;
+    return value;
   }
 
   @override


### PR DESCRIPTION
Fixes a couple instances where we weren't returning the deleted value when calling `storage.delete`.