### PR TITLE
chore(native_auth): Use version comparison tool from `objective_c` package

### DIFF
--- a/packages/native/authentication/CHANGELOG.md
+++ b/packages/native/authentication/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - chore: Bump `ffigen` and `objective_c` dependencies
 - chore: Bump minimum Dart SDK version to 3.6.0
+- chore: Use version comparison tool from `objective_c` package
 
 # 0.1.4
 

--- a/packages/native/authentication/lib/src/platform/native_auth.ios.dart
+++ b/packages/native/authentication/lib/src/platform/native_auth.ios.dart
@@ -7,6 +7,7 @@ import 'package:native_authentication/src/model/callback_session.dart';
 import 'package:native_authentication/src/native/ios/authentication_services.ffi.dart';
 import 'package:native_authentication/src/native_auth.platform_io.dart';
 import 'package:objective_c/objective_c.dart' as objc;
+import 'package:pub_semver/pub_semver.dart';
 
 // ignore: camel_case_types
 typedef _ObjCBlock_ffiVoid_NSURL_NSError
@@ -122,32 +123,23 @@ extension on CallbackType {
   /// The version of iOS that supports the latest callback schemes (HTTPS).
   ///
   /// https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/callback
-  static const String supportsNewCallbacksVersion = '17.4';
+  static final Version supportsNewCallbacksVersion = Version(17, 4, 0);
 
   /// Whether the current iOS version supports the new callback schemes.
   static bool get _supportsNewCallbacks {
-    return iosVersion.compare$1(
-          supportsNewCallbacksVersion.toNSString(),
-          options: objc.NSStringCompareOptions.NSNumericSearch,
-        ) !=
-        objc.NSComparisonResult.NSOrderedAscending;
+    return objc.checkOSVersion(iOS: supportsNewCallbacksVersion);
   }
 
   /// Throws if the current iOS version does not support the new callback
   /// schemes.
   void _ensureNewCallbacksSupport() {
     if (!_supportsNewCallbacks) {
-      throw ArgumentError.value(
-        this,
-        'callbackScheme',
+      throw UnsupportedError(
         'HTTPS scheme is only supported on iOS >=$supportsNewCallbacksVersion. '
-            'Current version: $iosVersion',
+        'Current version: ${objc.osVersion}',
       );
     }
   }
-
-  static objc.NSString get iosVersion =>
-      UIDevice.getCurrentDevice().systemVersion;
 
   ASWebAuthenticationSession session({
     required objc.NSURL url,

--- a/packages/native/authentication/lib/src/platform/native_auth.macos.dart
+++ b/packages/native/authentication/lib/src/platform/native_auth.macos.dart
@@ -6,6 +6,7 @@ import 'package:native_authentication/src/model/callback_session.dart';
 import 'package:native_authentication/src/native/macos/authentication_services.ffi.dart';
 import 'package:native_authentication/src/platform/native_auth.desktop.dart';
 import 'package:objective_c/objective_c.dart' as objc;
+import 'package:pub_semver/pub_semver.dart';
 
 // ignore: camel_case_types
 typedef _ObjCBlock_ffiVoid_NSURL_NSError
@@ -127,32 +128,23 @@ extension on CallbackType {
   /// The version of macOS that supports the latest callback schemes (HTTPS).
   ///
   /// https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/callback
-  static const String supportsNewCallbacksVersion = '14.4';
+  static final Version supportsNewCallbacksVersion = Version(14, 4, 0);
 
   /// Whether the current macOS version supports the new callback schemes.
   static bool get _supportsNewCallbacks {
-    return macosVersion.compare$1(
-          supportsNewCallbacksVersion.toNSString(),
-          options: objc.NSStringCompareOptions.NSNumericSearch,
-        ) !=
-        objc.NSComparisonResult.NSOrderedAscending;
+    return objc.checkOSVersion(macOS: supportsNewCallbacksVersion);
   }
 
   /// Throws if the current macOS version does not support the new callback
   /// schemes.
   void _ensureNewCallbacksSupport() {
     if (!_supportsNewCallbacks) {
-      throw ArgumentError.value(
-        this,
-        'callbackScheme',
+      throw UnsupportedError(
         'HTTPS scheme is only supported on macOS >=$supportsNewCallbacksVersion. '
-            'Current version: $macosVersion',
+        'Current version: ${objc.osVersion}',
       );
     }
   }
-
-  static objc.NSString get macosVersion =>
-      NSProcessInfo.getProcessInfo().operatingSystemVersionString;
 
   ASWebAuthenticationSession session({
     required objc.NSURL url,

--- a/packages/native/authentication/pubspec.yaml
+++ b/packages/native/authentication/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   meta: ^1.12.0
   objective_c: ^8.0.0
   path: ^1.9.0
+  pub_semver: ^2.2.0
   stream_transform: ^2.1.0
   web: ^1.0.0
 


### PR DESCRIPTION
Use `checkOSVersion` from `package:objective_c` instead of rolling our own version check.