### PR TITLE
chore(native_auth): Consolidate cancellation handling

### DIFF
--- a/packages/native/authentication/CHANGELOG.md
+++ b/packages/native/authentication/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- Adds a `NativeAuthCanceledException` type which is thrown when the user cancels the authentication flow.
+
 # 0.1.5
 
 - chore: Bump `ffigen` and `objective_c` dependencies

--- a/packages/native/authentication/example/lib/main.dart
+++ b/packages/native/authentication/example/lib/main.dart
@@ -43,7 +43,7 @@ class _MyAppState extends State<MyApp> {
       return localhost;
     }
     return switch (Platform.operatingSystem) {
-      'ios' || 'android' || 'macos' => const CallbackType.custom('celest'),
+      'ios' || 'android' || 'macos' => const CallbackType.custom('myapp'),
       _ => localhost,
     };
   }

--- a/packages/native/authentication/lib/src/model/callback_session.dart
+++ b/packages/native/authentication/lib/src/model/callback_session.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:meta/meta.dart';
 
@@ -15,7 +14,7 @@ abstract class CallbackSession {
   void cancel();
 
   @override
-  int get hashCode => Object.hash(CallbackSession, id);
+  int get hashCode => id.hashCode;
 
   @override
   bool operator ==(Object other) => other is CallbackSession && other.id == id;
@@ -29,10 +28,10 @@ final class NativeAuthCallbackSessionImpl extends CallbackSession {
     this._cancel,
   );
 
-  static final Random _random = Random();
+  static int _nextId = 1;
 
   @internal
-  static int nextId() => _random.nextInt(1 << 10);
+  static int nextId() => _nextId++;
 
   @override
   final int id;

--- a/packages/native/authentication/lib/src/model/callback_type.dart
+++ b/packages/native/authentication/lib/src/model/callback_type.dart
@@ -118,6 +118,6 @@ final class CallbackTypeCustom extends CallbackType {
 
   @override
   String toString() {
-    return '$scheme:$host$path';
+    return '$scheme://$host$path';
   }
 }

--- a/packages/native/authentication/lib/src/model/exception.dart
+++ b/packages/native/authentication/lib/src/model/exception.dart
@@ -22,6 +22,23 @@ abstract interface class NativeAuthException {
   Object? get underlyingError;
 }
 
+/// Thrown when the user cancels the native authentication process.
+final class NativeAuthCanceledException implements NativeAuthException {
+  /// Creates a new [NativeAuthCanceledException] with the given [message].
+  const NativeAuthCanceledException(this.id);
+
+  final int id;
+
+  @override
+  String get message => 'Redirect canceled by user (id=$id)';
+
+  @override
+  Object? get underlyingError => null;
+
+  @override
+  String toString() => message;
+}
+
 class _NativeAuthExceptionImpl implements NativeAuthException {
   const _NativeAuthExceptionImpl(
     this.message, {

--- a/packages/native/authentication/lib/src/native_auth.platform_web.dart
+++ b/packages/native/authentication/lib/src/native_auth.platform_web.dart
@@ -3,19 +3,10 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:native_authentication/native_authentication.dart';
 import 'package:native_authentication/src/model/callback_session.dart';
-import 'package:path/path.dart';
 import 'package:web/web.dart';
 
 final class NativeAuthenticationPlatform implements NativeAuthentication {
   NativeAuthenticationPlatform({Logger? logger});
-
-  /// The base URL, to which all local paths are relative.
-  // ignore: unused_element
-  String get _baseUrl {
-    final baseElement = document.querySelector('base');
-    final basePath = baseElement?.getAttribute('href') ?? '/';
-    return url.join(window.location.origin, basePath);
-  }
 
   @override
   CallbackSession startCallback({

--- a/packages/native/authentication/lib/src/platform/native_auth.android.dart
+++ b/packages/native/authentication/lib/src/platform/native_auth.android.dart
@@ -48,9 +48,7 @@ final class NativeAuthenticationAndroid extends NativeAuthenticationPlatform {
               completer.complete(Uri.parse(url));
             case android.NativeAuthentication.RESULT_CANCELED:
               completer.completeError(
-                NativeAuthException(
-                  'Redirect canceled by user (id=$sessionId)',
-                ),
+                NativeAuthCanceledException(sessionId),
               );
             case android.NativeAuthentication.RESULT_FAILURE:
               final message = state


### PR DESCRIPTION
- Adds a new `NativeAuthCanceledException` exception type and updates all impls to throw when canceling a callback.
- Improves error handling on Darwin platforms